### PR TITLE
fix 'TypeError: controlElevation is undefined'

### DIFF
--- a/leaflet-elevation.js
+++ b/leaflet-elevation.js
@@ -165,6 +165,7 @@ L.Control.Elevation = L.Control.extend({
 		} else {
 			L.Control.prototype.addTo.call(this, map);
 		}
+  		return this;
 	},
 
 	/*


### PR DESCRIPTION
After following the steps of your Readme.md file

```js
  // Instantiate elevation control.
  var controlElevation = L.control.elevation(elevation_options).addTo(map);

  // Load track from url (allowed data types: "*.geojson", "*.gpx")
  controlElevation.load("https://raruto.github.io/examples/leaflet-elevation/via-emilia.gpx");
```

I encountered the following error:
```
TypeError: controlElevation is undefined
```

This change solved it for me. 

```js
  var controlElevation = L.control.elevation(elevation_options);
  controlElevation.addTo(map);
```