### PR TITLE
Rename .hidden class to .leaflet-hidden

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -281,7 +281,7 @@ export var Chart = L.Class.extend({
 	_appendMouseFocusG: function() {
 		return g => {
 			let focusG = this._focusG = g.append("g")
-				.attr("class", "mouse-focus-group hidden");
+				.attr("class", "mouse-focus-group leaflet-hidden");
 
 			this._focusline = focusG.append('svg:line')
 				.call(
@@ -396,12 +396,12 @@ export var Chart = L.Class.extend({
 	_appendRuler: function() {
 		const dragstart = function(d) {
 			this._hideDiagramIndicator();
-			this._container.select(".horizontal-drag-label").classed('hidden', false);
+			this._container.select(".horizontal-drag-label").classed('leaflet-hidden', false);
 		}
 
 		const dragend = function(d) {
 			let y = this._container.select('.horizontal-drag-group').node().transform.baseVal.consolidate().matrix.f;
-			this._container.select(".horizontal-drag-label").classed('hidden', y >= this._height() || y <= 0)
+			this._container.select(".horizontal-drag-label").classed('leaflet-hidden', y >= this._height() || y <= 0)
 		};
 
 		const dragged = function(d) {
@@ -627,7 +627,7 @@ export var Chart = L.Class.extend({
 		let opts = this.options;
 		let yCoordinate = this._y(item[opts.yAttr]);
 
-		this._focusG.classed("hidden", false);
+		this._focusG.classed("leaflet-hidden", false);
 
 		this._focusline.call(
 			D3.MouseFocusLine({
@@ -648,7 +648,7 @@ export var Chart = L.Class.extend({
 	},
 
 	_hideDiagramIndicator: function() {
-		this._focusG.classed("hidden", true);
+		this._focusG.classed("leaflet-hidden", true);
 	},
 });
 

--- a/src/control.js
+++ b/src/control.js
@@ -815,15 +815,15 @@ Elevation.addInitHook(function() {
 	this.on('elepath_toggle', function(e) {
 		let path = e.path;
 		let optName = path.getAttribute('data-name').toLowerCase();
-		let enable = _.hasClass(path, 'hidden');
+		let enable = _.hasClass(path, 'leaflet-hidden');
 		let label = _.select('text', e.legend);
 		let rect = _.select('rect', e.legend);
 
 		_.style(label, "text-decoration-line", enable ? "" : "line-through")
 		_.style(rect, "fill-opacity", enable ? "" : "0")
-		_.toggleClass(path, 'hidden', !enable);
+		_.toggleClass(path, 'leaflet-hidden', !enable);
 
-		this._chartEnabled = this._chart._area.selectAll('path:not(.hidden)').nodes().length != 0;
+		this._chartEnabled = this._chart._area.selectAll('path:not(.leaflet-hidden)').nodes().length != 0;
 		this._layers.eachLayer(l => _.toggleClass(l.getElement && l.getElement(), this.options.polyline.className + ' ' + this.options.theme, this._chartEnabled));
 		this.options[optName] = enable && this.options[optName] == 'disabled' ? 'enabled' : 'disabled';
 
@@ -854,7 +854,7 @@ Elevation.addInitHook(function() {
 				d3.select(target).on('click', () => this._fireEvt("elepath_toggle", { path: path, name: name, legend: target }));
 				// Set initial chart area state
 				if (path && optName in this.options && this.options[optName] == 'disabled') {
-					path.classList.add('hidden');
+					path.classList.add('leaflet-hidden');
 					target.querySelector('text').style.textDecorationLine = "line-through";
 					target.querySelector('rect').style.fillOpacity = "0";
 				}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-.hidden {
+.leaflet-hidden {
   visibility: hidden;
 }
 

--- a/src/marker.js
+++ b/src/marker.js
@@ -62,7 +62,7 @@ export var Marker = L.Class.extend({
 			let normalizedAlt = this._height() / props.maxElevation * point.z;
 			let normalizedY = point.y - normalizedAlt;
 
-			this._container.classed("hidden", false);
+			this._container.classed("leaflet-hidden", false);
 
 			this._focusmarker
 				.call(
@@ -92,7 +92,7 @@ export var Marker = L.Class.extend({
 					})
 				);
 		} else if (this.options.marker == 'position-marker') {
-			_.removeClass(this._marker.getElement(), 'hidden');
+			_.removeClass(this._marker.getElement(), 'leaflet-hidden');
 			this._marker.setLatLng(this._latlng);
 		}
 	},
@@ -102,9 +102,9 @@ export var Marker = L.Class.extend({
 	 */
 	remove: function() {
 		if (this.options.marker == 'elevation-line') {
-			if (this._container) this._container.classed("hidden", true);
+			if (this._container) this._container.classed("leaflet-hidden", true);
 		} else if (this.options.marker == 'position-marker') {
-			_.addClass(this._marker.getElement(), 'hidden');
+			_.addClass(this._marker.getElement(), 'leaflet-hidden');
 		}
 	},
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,7 @@ export function isVisible(elem) {
 	let styles = window.getComputedStyle(elem);
 
 	function isVisibleByStyles(elem, styles) {
-		return styles.visibility !== 'leaflet-hidden' && styles.display !== 'none';
+		return styles.visibility !== 'hidden' && styles.display !== 'none';
 	}
 
 	function isAboveOtherElements(elem, styles) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,7 @@ export function isVisible(elem) {
 	let styles = window.getComputedStyle(elem);
 
 	function isVisibleByStyles(elem, styles) {
-		return styles.visibility !== 'hidden' && styles.display !== 'none';
+		return styles.visibility !== 'leaflet-hidden' && styles.display !== 'none';
 	}
 
 	function isAboveOtherElements(elem, styles) {


### PR DESCRIPTION
Helps avoid conflicts (in example with [TailwindCSS](https://tailwindcss.com/)) by using a less general classname.