### PR TITLE
Do not parse waypoints

### DIFF
--- a/libs/leaflet-gpxgroup.js
+++ b/libs/leaflet-gpxgroup.js
@@ -137,6 +137,9 @@ L.GpxGroup = L.Class.extend({
       startIconUrl: null,
       endIconUrl: null,
       shadowUrl: null,
+    },
+    gpx_options: {
+      parseElements: ["track", "route"],
     }
   },
 
@@ -204,7 +207,8 @@ L.GpxGroup = L.Class.extend({
     var route = new L.GPX(data, {
       async: this.options.async,
       marker_options: this.options.marker_options,
-      polyline_options: line_style
+      polyline_options: line_style,
+      gpx_options: this.options.gpx_options,
     });
 
     route.originalStyle = line_style;


### PR DESCRIPTION
If the tracks contain waypoints, then it becomes confusing:
![grafik](https://user-images.githubusercontent.com/73023225/134704841-585a596b-451a-4cd3-b253-79cf00fe3695.png)
The changed code don't parse this waypoints:
![grafik](https://user-images.githubusercontent.com/73023225/134705025-bc839a65-ac74-47d8-971a-da30a81156f2.png)
