### PR TITLE
add option to set stroke outline color

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -1112,7 +1112,7 @@ Elevation.addInitHook(function() {
 				if (options.stroke && options.weight !== 0) {
 					let oldVal                   = ctx.globalCompositeOperation || 'source-over';
 					ctx.globalCompositeOperation = 'destination-over'
-					ctx.strokeStyle              = '#FFF';
+					ctx.strokeStyle              = colors.outline || '#FFF';
 					ctx.lineWidth                = options.weight * 1.75;
 					ctx.stroke();
 					ctx.globalCompositeOperation = oldVal;

--- a/src/control.js
+++ b/src/control.js
@@ -1112,7 +1112,7 @@ Elevation.addInitHook(function() {
 				if (options.stroke && options.weight !== 0) {
 					let oldVal                   = ctx.globalCompositeOperation || 'source-over';
 					ctx.globalCompositeOperation = 'destination-over'
-					ctx.strokeStyle              = colors.outline || '#FFF';
+					ctx.strokeStyle              = color.outline || '#FFF';
 					ctx.lineWidth                = options.weight * 1.75;
 					ctx.stroke();
 					ctx.globalCompositeOperation = oldVal;


### PR DESCRIPTION
I found no other way to set the outline of the track to a different color so that a track looks like this: (no white outline).
The yellow fill color can be set using colors: 'theme-name': line and I found it useful that the outline color can be set in the same spot:

```js
colors: {
    'steelblue': {
        line: 'yellow',           // existing option
        outline: 'rgb(50,50,50)', // new option
    },
},
```

![image](https://user-images.githubusercontent.com/527787/151945565-f4601ce4-39c2-48c2-9a19-c0e3c34c60c2.png)
