### PR TITLE
Fix: `imperial: true` does not convert elevation from meters to feet

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -352,7 +352,7 @@ export const Elevation = L.Control.Elevation = L.Control.extend({
 			this._addPoint(
 				point.lat ?? point[1], 
 				point.lng ?? point[0],
-				point.alt ?? point.meta.ele ?? (point[2] * this.options.altitudeFactor)
+				point.alt ?? point.meta.ele ?? point[2]
 			);
 
 			this.fire("elepoint_added", { point: point, index: this._data.length - 1 });
@@ -426,7 +426,7 @@ export const Elevation = L.Control.Elevation = L.Control.extend({
 			.then(() => {
 				layer.eachLayer((trkseg) => {
 					if(trkseg.feature.geometry.type != "Point") {
-						let geo = L.geoJson(trkseg.toGeoJSON(), { coordsToLatLng: (coords) => L.latLng(coords[0], coords[1], coords[2] * this.options.altitudeFactor)});
+						let geo = L.geoJson(trkseg.toGeoJSON(), { coordsToLatLng: (coords) => L.latLng(coords[0], coords[1], coords[2] * (this.options.altitudeFactor || 1))});
 						let line = L.hotline(geo.toGeoJSON().features[0].geometry.coordinates, {
 							min: isFinite(this.track_info[prop + '_min']) ? this.track_info[prop + '_min'] : 0,
 							max: isFinite(this.track_info[prop + '_max']) ? this.track_info[prop + '_max'] : 1,

--- a/src/control.js
+++ b/src/control.js
@@ -426,7 +426,7 @@ export const Elevation = L.Control.Elevation = L.Control.extend({
 			.then(() => {
 				layer.eachLayer((trkseg) => {
 					if(trkseg.feature.geometry.type != "Point") {
-						let geo = L.geoJson(trkseg.toGeoJSON(), { coordsToLatLng: (coords) => L.latLng(coords[0], coords[1], coords[2])});
+						let geo = L.geoJson(trkseg.toGeoJSON(), { coordsToLatLng: (coords) => L.latLng(coords[0], coords[1], coords[2] * this.options.altitudeFactor)});
 						let line = L.hotline(geo.toGeoJSON().features[0].geometry.coordinates, {
 							min: isFinite(this.track_info[prop + '_min']) ? this.track_info[prop + '_min'] : 0,
 							max: isFinite(this.track_info[prop + '_max']) ? this.track_info[prop + '_max'] : 1,

--- a/src/handlers/altitude.js
+++ b/src/handlers/altitude.js
@@ -26,7 +26,7 @@ export function Altitude() {
 		// },
 		pointToAttr: (point, i) => {
 			if ("alt" in point) point.meta.ele = point.alt; // "alt" property is generated inside "leaflet"
-			return this._data[i].z;
+			return this._data[i].z *= opts.altitudeFactor;
 		},
 		stats: { max: _.iMax, min: _.iMin, avg: _.iAvg },
 		grid: {

--- a/src/handlers/altitude.js
+++ b/src/handlers/altitude.js
@@ -26,7 +26,7 @@ export function Altitude() {
 		// },
 		pointToAttr: (point, i) => {
 			if ("alt" in point) point.meta.ele = point.alt; // "alt" property is generated inside "leaflet"
-			return this._data[i].z * opts.altitudeFactor;
+			return this._data[i].z;
 		},
 		stats: { max: _.iMax, min: _.iMin, avg: _.iAvg },
 		grid: {

--- a/test/index.html
+++ b/test/index.html
@@ -152,7 +152,7 @@
 					detached: true,
 					closeBtn: true,
 					summary: "inline",
-					imperial: false,
+					imperial: true,
 					altitude: true,
 					distance: true,
 					slope: "summary",


### PR DESCRIPTION
Now it should be correct. And it works setting `imperial: true`.

Related to: https://github.com/Raruto/leaflet-elevation/pull/196, closes https://github.com/Raruto/leaflet-elevation/issues/197, closes https://github.com/Raruto/leaflet-elevation/issues/195


