### PR TITLE
Prevent shallow copy of default options (multiple charts)

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -173,7 +173,8 @@ export const Elevation = L.Control.Elevation = L.Control.extend({
 	 */
 	initialize: function(opts) {
 
-		opts = L.setOptions(this, opts);
+		opts = L.setOptions(this, L.extend({}, structuredClone(Options), opts)); // "deep copy" nested objects (multiple charts)
+		
 
 		this._data           = [];
 		this._layers         = L.featureGroup();

--- a/src/control.js
+++ b/src/control.js
@@ -173,8 +173,10 @@ export const Elevation = L.Control.Elevation = L.Control.extend({
 	 */
 	initialize: function(opts) {
 
+		// opts = L.setOptions(this, opts);
+
+		// Fixes: https://github.com/Raruto/leaflet-elevation/pull/240
 		opts = L.setOptions(this, L.extend({}, structuredClone(Options), opts)); // "deep copy" nested objects (multiple charts)
-		
 
 		this._data           = [];
 		this._layers         = L.featureGroup();


### PR DESCRIPTION
## Before

```js
opts = L.setOptions(this, opts);
```

## After
```js
opts = L.setOptions(this, L.extend({}, structuredClone(Options), opts));
```

**More info:**

- https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
- https://github.com/Leaflet/Leaflet/blob/79986e279c0f366f59b29fa086800243540765f7/src/core/Util.js#L100-L110

---

Closes: https://github.com/Raruto/leaflet-elevation/issues/238