### PR TITLE
Fix undefined `track_info` data within "eledata_loaded" event

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -810,7 +810,12 @@ export const Elevation = L.Control.Elevation = L.Control.extend({
 
 		this.import(this.__D3).then(() => {
 			this._initMapIntegrations(layer);
-			this._fireEvt("eledata_loaded", { data: geojson, layer: layer, name: this.track_info.name, track_info: this.track_info });
+			const event_data = { data: geojson, layer: layer, name: this.track_info.name, track_info: this.track_info };
+			if (this._modulesLoaded) {
+				this._fireEvt("eledata_loaded", event_data);
+			} else {
+				this.once('modules_loaded', () => this._fireEvt("eledata_loaded", event_data));
+			}
 		});
 
 		return layer;

--- a/test/setup/http_server.js
+++ b/test/setup/http_server.js
@@ -47,6 +47,7 @@ export function suite() {
     test.before(setup);
     test.after(reset);
     test.before.each(async ({ localhost, page }) => {
+        page.on('console', msg => console.log(msg.text()))
         await page.goto((new URL(arguments[0], localhost)).toString());
     });
     // augment uvu `test` function with a third parameter `timeout`


### PR DESCRIPTION
## Subject of the issue

Calling `load()` and `on('eledata_loaded')` sequentially does not ensure that all [`src/handlers`](https://github.com/Raruto/leaflet-elevation/blob/b0006d635a048ec3d1db519819ad3a9813e7ffc6/src/handlers/) files are downloaded at callback execution time, that is:

```js
// waits until 'foo.gpx' is downloaded
controlElevation.on('eledata_loaded', ({track_info}) => console.log(track_info.distance)); // NB implicit dynamic import('src/handlers/distance.js')

// fetch 'foo.gpx'
controlElevation.load('foo.gpx'); 
```

## Solution adopted

Refactor `_loadLayer()` function, in order to wait until `this._modulesLoaded == true` before triggering `"eledata_loaded"` event, that is:

```js
const event_data = { data: geojson, layer: layer, name: this.track_info.name, track_info: this.track_info };

if (this._modulesLoaded) {
  this._fireEvt("eledata_loaded", event_data);
} else {
  this.once('modules_loaded', () => this._fireEvt("eledata_loaded", event_data));
}
```

Closes: https://github.com/Raruto/leaflet-elevation/issues/241