### PR TITLE
fix(markers): replace all spaces and quotes in waypoint sym class name 

### DIFF
--- a/src/control.js
+++ b/src/control.js
@@ -797,7 +797,7 @@ export const Elevation = L.Control.Elevation = L.Control.extend({
 					if ([true, 'markers'].includes(waypoints) && wptIcons != false) {
 						return this._registerMarker({
 							latlng : latlng,
-							sym    : (sym ?? name).replace(' ', '-').replace('"', '').replace("'", '').toLowerCase(),
+							sym    : (sym ?? name).replace(/["']/g, '').replace(/ /g, '-').toLowerCase(),
 							content: [true, 'markers'].includes(wptLabels) && (name || desc) && decodeURI("<b>" + name + "</b>" + (desc.length > 0 ? '<br>' + desc : ''))
 						});
 					}


### PR DESCRIPTION
`.replace(' ', '-').replace('"', '').replace("'", '')` on the waypoint `sym` only handles the first occurrence of each character. A GPX waypoint named `Rest area "north"` produces `rest-area north"` instead of `rest-area-north`: the surviving space splits the value into two classes so CSS keyed on the cleaned name never matches, and the surviving quote terminates the `class` attribute built in `_registerMarker()`.

Switching each call to a `/g` regex.

Flagged by CodeQL (`js/incomplete-sanitization`) on a downstream project that vendors leaflet-elevation.

Note: even with this fix the cleanup is a blocklist, so `<`, `>` and `&` still reach that attribute. An allowlist (`.replace(/[^\w-]+/g, '-')`) would close it properly, at the cost of rewriting existing sym values that contain dots or accented characters.
