### PR TITLE
fix(node): replace `assert` with `with` for JSON import (Node 22+)

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -7,7 +7,7 @@ import postcssImport from 'postcss-import';
 // import postcssCopy from 'postcss-copy';
 // import rollupGitVersion from 'rollup-plugin-git-version';
 
-import plugin from '../package.json' assert { type: "json" };
+import plugin from '../package.json' with { type: "json" };
 
 let plugin_name = plugin.name.replace("@raruto/", "");
 


### PR DESCRIPTION
`npm run build` and `npm run dev` fail on Node 22 and newer with `SyntaxError: Unexpected identifier 'assert'`. `build/rollup.config.js` imports `package.json` with the `assert { type: "json" }` import-attribute syntax, which Node replaced with `with` and removed in v22.

#307 brought the test harness up to date for Node 22, but the build config kept the old syntax, so `npm run dev` (step 3 of the local setup in CONTRIBUTING.md) still stops before rollup starts.

Verified on Node 26.5.0: rollup exits with that SyntaxError before the change, and emits all four `dist` artifacts after it.

Note that `with` requires Node >= 18.20 or >= 20.10.
